### PR TITLE
feat: implement emotion view

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@next/third-parties": "^15.2.1",
     "avvvatars-react": "^0.4.2",
     "clsx": "^2.1.1",
+    "emoji-picker-react": "^4.12.2",
     "framer-motion": "^12.0.5",
     "next": "15.1.0",
     "nextjs-toploader": "^3.7.15",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clsx": "^2.1.1",
     "emoji-picker-react": "^4.12.2",
     "framer-motion": "^12.0.5",
-    "next": "15.1.0",
+    "next": "15.2.4",
     "nextjs-toploader": "^3.7.15",
     "notion-client": "^7.1.6",
     "notion-types": "^7.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,7 +22,7 @@ importers:
         version: 2.2.0(react@19.0.0)
       '@next/third-parties':
         specifier: ^15.2.1
-        version: 15.2.1(next@15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
+        version: 15.2.1(next@15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)
       avvvatars-react:
         specifier: ^0.4.2
         version: 0.4.2(csstype@3.1.3)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -36,11 +36,11 @@ importers:
         specifier: ^12.0.5
         version: 12.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next:
-        specifier: 15.1.0
-        version: 15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: 15.2.4
+        version: 15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       nextjs-toploader:
         specifier: ^3.7.15
-        version: 3.7.15(next@15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        version: 3.7.15(next@15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       notion-client:
         specifier: ^7.1.6
         version: 7.1.6
@@ -923,56 +923,56 @@ packages:
       katex: '>=0.9'
       react: '>=16'
 
-  '@next/env@15.1.0':
-    resolution: {integrity: sha512-UcCO481cROsqJuszPPXJnb7GGuLq617ve4xuAyyNG4VSSocJNtMU5Fsx+Lp6mlN8c7W58aZLc5y6D/2xNmaK+w==}
+  '@next/env@15.2.4':
+    resolution: {integrity: sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g==}
 
   '@next/eslint-plugin-next@15.2.0':
     resolution: {integrity: sha512-jHFUG2OwmAuOASqq253RAEG/5BYcPHn27p1NoWZDCf4OdvdK0yRYWX92YKkL+Mk2s+GyJrmd/GATlL5b2IySpw==}
 
-  '@next/swc-darwin-arm64@15.1.0':
-    resolution: {integrity: sha512-ZU8d7xxpX14uIaFC3nsr4L++5ZS/AkWDm1PzPO6gD9xWhFkOj2hzSbSIxoncsnlJXB1CbLOfGVN4Zk9tg83PUw==}
+  '@next/swc-darwin-arm64@15.2.4':
+    resolution: {integrity: sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@15.1.0':
-    resolution: {integrity: sha512-DQ3RiUoW2XC9FcSM4ffpfndq1EsLV0fj0/UY33i7eklW5akPUCo6OX2qkcLXZ3jyPdo4sf2flwAED3AAq3Om2Q==}
+  '@next/swc-darwin-x64@15.2.4':
+    resolution: {integrity: sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@15.1.0':
-    resolution: {integrity: sha512-M+vhTovRS2F//LMx9KtxbkWk627l5Q7AqXWWWrfIzNIaUFiz2/NkOFkxCFyNyGACi5YbA8aekzCLtbDyfF/v5Q==}
+  '@next/swc-linux-arm64-gnu@15.2.4':
+    resolution: {integrity: sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-arm64-musl@15.1.0':
-    resolution: {integrity: sha512-Qn6vOuwaTCx3pNwygpSGtdIu0TfS1KiaYLYXLH5zq1scoTXdwYfdZtwvJTpB1WrLgiQE2Ne2kt8MZok3HlFqmg==}
+  '@next/swc-linux-arm64-musl@15.2.4':
+    resolution: {integrity: sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@next/swc-linux-x64-gnu@15.1.0':
-    resolution: {integrity: sha512-yeNh9ofMqzOZ5yTOk+2rwncBzucc6a1lyqtg8xZv0rH5znyjxHOWsoUtSq4cUTeeBIiXXX51QOOe+VoCjdXJRw==}
+  '@next/swc-linux-x64-gnu@15.2.4':
+    resolution: {integrity: sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-linux-x64-musl@15.1.0':
-    resolution: {integrity: sha512-t9IfNkHQs/uKgPoyEtU912MG6a1j7Had37cSUyLTKx9MnUpjj+ZDKw9OyqTI9OwIIv0wmkr1pkZy+3T5pxhJPg==}
+  '@next/swc-linux-x64-musl@15.2.4':
+    resolution: {integrity: sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@next/swc-win32-arm64-msvc@15.1.0':
-    resolution: {integrity: sha512-WEAoHyG14t5sTavZa1c6BnOIEukll9iqFRTavqRVPfYmfegOAd5MaZfXgOGG6kGo1RduyGdTHD4+YZQSdsNZXg==}
+  '@next/swc-win32-arm64-msvc@15.2.4':
+    resolution: {integrity: sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@15.1.0':
-    resolution: {integrity: sha512-J1YdKuJv9xcixzXR24Dv+4SaDKc2jj31IVUEMdO5xJivMTXuE6MAdIi4qPjSymHuFG8O5wbfWKnhJUcHHpj5CA==}
+  '@next/swc-win32-x64-msvc@15.2.4':
+    resolution: {integrity: sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -2308,8 +2308,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@15.1.0:
-    resolution: {integrity: sha512-QKhzt6Y8rgLNlj30izdMbxAwjHMFANnLwDwZ+WQh5sMhyt4lEBqDK9QpvWHtIM4rINKPoJ8aiRZKg5ULSybVHw==}
+  next@15.2.4:
+    resolution: {integrity: sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ==}
     engines: {node: ^18.18.0 || ^19.8.0 || >= 20.0.0}
     hasBin: true
     peerDependencies:
@@ -4112,39 +4112,39 @@ snapshots:
       katex: 0.16.21
       react: 19.0.0
 
-  '@next/env@15.1.0': {}
+  '@next/env@15.2.4': {}
 
   '@next/eslint-plugin-next@15.2.0':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@15.1.0':
+  '@next/swc-darwin-arm64@15.2.4':
     optional: true
 
-  '@next/swc-darwin-x64@15.1.0':
+  '@next/swc-darwin-x64@15.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@15.1.0':
+  '@next/swc-linux-arm64-gnu@15.2.4':
     optional: true
 
-  '@next/swc-linux-arm64-musl@15.1.0':
+  '@next/swc-linux-arm64-musl@15.2.4':
     optional: true
 
-  '@next/swc-linux-x64-gnu@15.1.0':
+  '@next/swc-linux-x64-gnu@15.2.4':
     optional: true
 
-  '@next/swc-linux-x64-musl@15.1.0':
+  '@next/swc-linux-x64-musl@15.2.4':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@15.1.0':
+  '@next/swc-win32-arm64-msvc@15.2.4':
     optional: true
 
-  '@next/swc-win32-x64-msvc@15.1.0':
+  '@next/swc-win32-x64-msvc@15.2.4':
     optional: true
 
-  '@next/third-parties@15.2.1(next@15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
+  '@next/third-parties@15.2.1(next@15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react@19.0.0)':
     dependencies:
-      next: 15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react: 19.0.0
       third-party-capital: 1.0.20
 
@@ -5691,9 +5691,9 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  next@15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      '@next/env': 15.1.0
+      '@next/env': 15.2.4
       '@swc/counter': 0.1.3
       '@swc/helpers': 0.5.15
       busboy: 1.6.0
@@ -5703,22 +5703,22 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(@babel/core@7.26.7)(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 15.1.0
-      '@next/swc-darwin-x64': 15.1.0
-      '@next/swc-linux-arm64-gnu': 15.1.0
-      '@next/swc-linux-arm64-musl': 15.1.0
-      '@next/swc-linux-x64-gnu': 15.1.0
-      '@next/swc-linux-x64-musl': 15.1.0
-      '@next/swc-win32-arm64-msvc': 15.1.0
-      '@next/swc-win32-x64-msvc': 15.1.0
+      '@next/swc-darwin-arm64': 15.2.4
+      '@next/swc-darwin-x64': 15.2.4
+      '@next/swc-linux-arm64-gnu': 15.2.4
+      '@next/swc-linux-arm64-musl': 15.2.4
+      '@next/swc-linux-x64-gnu': 15.2.4
+      '@next/swc-linux-x64-musl': 15.2.4
+      '@next/swc-win32-arm64-msvc': 15.2.4
+      '@next/swc-win32-x64-msvc': 15.2.4
       sharp: 0.33.5
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextjs-toploader@3.7.15(next@15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+  nextjs-toploader@3.7.15(next@15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0))(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
-      next: 15.1.0(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      next: 15.2.4(@babel/core@7.26.7)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       nprogress: 0.2.0
       prop-types: 15.8.1
       react: 19.0.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      emoji-picker-react:
+        specifier: ^4.12.2
+        version: 4.12.2(react@19.0.0)
       framer-motion:
         specifier: ^12.0.5
         version: 12.0.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1527,6 +1530,12 @@ packages:
   electron-to-chromium@1.5.88:
     resolution: {integrity: sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==}
 
+  emoji-picker-react@4.12.2:
+    resolution: {integrity: sha512-6PDYZGlhidt+Kc0ay890IU4HLNfIR7/OxPvcNxw+nJ4HQhMKd8pnGnPn4n2vqC/arRFCNWQhgJP8rpsYKsz0GQ==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: '>=16'
+
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
@@ -1769,6 +1778,9 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
+
+  flairup@1.0.0:
+    resolution: {integrity: sha512-IKlE+pNvL2R+kVL1kEhUYqRxVqeFnjiIvHWDMLFXNaqyUdFXQM2wte44EfMYJNHkW16X991t2Zg8apKkhv7OBA==}
 
   flat-cache@4.0.1:
     resolution: {integrity: sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==}
@@ -4749,6 +4761,11 @@ snapshots:
 
   electron-to-chromium@1.5.88: {}
 
+  emoji-picker-react@4.12.2(react@19.0.0):
+    dependencies:
+      flairup: 1.0.0
+      react: 19.0.0
+
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
@@ -5162,6 +5179,8 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
+
+  flairup@1.0.0: {}
 
   flat-cache@4.0.1:
     dependencies:

--- a/src/api/mutation/diary-mutation.ts
+++ b/src/api/mutation/diary-mutation.ts
@@ -6,16 +6,18 @@ import { getCommonFetchConfig } from '@/api/config';
 export interface CreateDiaryMutationParams {
   readonly title: string;
   readonly content: string;
+  readonly emoji: string;
 }
 
 export const createDiaryMutation = async ({
   title,
-  content
+  content,
+  emoji
 }: CreateDiaryMutationParams): Promise<ApiResponse<void>> => {
   try {
     const response = await fetch(`${API_HOST}/diary`, {
       method: 'POST',
-      body: JSON.stringify({ title, content }),
+      body: JSON.stringify({ title, content, emoji }),
       ...(await getCommonFetchConfig())
     });
     return interceptResponse(response);
@@ -27,16 +29,17 @@ export const createDiaryMutation = async ({
 export interface UpdateDiaryMutationParams {
   readonly title: string;
   readonly content: string;
+  readonly emoji: string;
 }
 
 export const updateDiaryMutation = async (
   diaryId: number,
-  { title, content }: UpdateDiaryMutationParams
+  { title, content, emoji }: UpdateDiaryMutationParams
 ): Promise<ApiResponse<void>> => {
   try {
     const response = await fetch(`${API_HOST}/diary/${diaryId}`, {
       method: 'PUT',
-      body: JSON.stringify({ title, content }),
+      body: JSON.stringify({ title, content, emoji }),
       ...(await getCommonFetchConfig())
     });
     return interceptResponse(response);

--- a/src/api/query/diary-query.ts
+++ b/src/api/query/diary-query.ts
@@ -7,6 +7,7 @@ export interface GetAllDiaryQueryReturn {
   readonly content: Array<{
     readonly diaryId: number;
     readonly title: string;
+    readonly emoji: string;
     readonly createdAt: Date;
     readonly updatedAt: Date;
   }>;

--- a/src/api/query/diary-query.ts
+++ b/src/api/query/diary-query.ts
@@ -34,6 +34,7 @@ export interface GetDiaryQueryReturn {
   readonly diaryId: number;
   readonly title: string;
   readonly content: string;
+  readonly emoji: string;
   readonly createdAt: Date;
   readonly updatedAt: Date;
 }

--- a/src/app/diary/[id]/page.tsx
+++ b/src/app/diary/[id]/page.tsx
@@ -47,7 +47,7 @@ const Page: FC<{ params: Promise<{ id: string }> }> = async ({ params }) => {
     <Container className="mt-12 lg:mt-20">
       <div className="flex flex-col space-y-4 lg:flex-row lg:items-center lg:justify-between lg:space-y-0">
         <PageTitle
-          title={diary.result.title}
+          title={`${diary.result.emoji} ${diary.result.title}`}
           description={`${diaryDate.getFullYear()}년 ${diaryDate.getMonth() + 1}월 ${diaryDate.getDate()}일`}
         />
         <div className="flex flex-shrink-0 space-x-2">

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,5 +1,5 @@
 @import url('https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/variable/pretendardvariable-dynamic-subset.min.css');
-@import url('https://tetunori.github.io/fluent-emoji-webfont/dist/FluentEmojiColor.css');
+@import url('https://tetunori.github.io/fluent-emoji-webfont/dist/FluentEmojiFlat.css');
 
 @tailwind base;
 @tailwind components;

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -65,13 +65,14 @@ const Page: FC = () => {
       <PageTitle title="일기 쓰기" description="새로운 일기를 쓸 수 있어요." />
       <div className="mt-16">
         <Input
-          placeholder="일기 제목을 입력해주세요. 빈 칸으로 두면 오늘 날짜로 채워드릴게요."
+          placeholder="제목을 빈 칸으로 두면 오늘 날짜로 채워드릴게요."
           value={title}
           onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
           className="mb-4"
         />
         <Editor value={content} onChange={setContent} />
-        <div className="mt-10 flex justify-end">
+        <div className="mt-10 flex items-center justify-end">
+          <p className="mr-4 text-sm text-gray-500">{content.length}/500</p>
           <Button className="bg-green-600 text-white hover:bg-green-700" onClick={onSaveClick}>
             저장하기
           </Button>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -13,6 +13,7 @@ import { EMOJI_LIST } from '@/constants/emoji';
 import { editorPreprocessor } from '@/utils/diary-preprocessor';
 import { DiaryWriteDataForm } from '@/app/write/type';
 import EmojiPicker from '@/components/EmojiPicker';
+import { DIARY_MAX_LENGTH, EMOJI_MAX_LENGTH } from '@/constants/diary-validation';
 
 const Page: FC = () => {
   const router = useRouter();
@@ -27,6 +28,14 @@ const Page: FC = () => {
   const validateInput = () => {
     if (writeData.content.trim() === '') {
       toast('일기 내용이 비어있어요.', { icon: EMOJI_LIST.PENCIL });
+      return false;
+    }
+    if (writeData.content.length > DIARY_MAX_LENGTH) {
+      toast(`일기 내용을 ${DIARY_MAX_LENGTH}자 이하로 줄여주세요.`, { icon: EMOJI_LIST.PENCIL });
+      return false;
+    }
+    if (writeData.emoji.length > EMOJI_MAX_LENGTH) {
+      toast('이모지 외 다른 글자가 들어있어요.', { icon: EMOJI_LIST.PENCIL });
       return false;
     }
 
@@ -46,7 +55,8 @@ const Page: FC = () => {
 
       await createDiaryMutation({
         title: writeData.title.trim() === '' ? defaultTitle : writeData.title,
-        content: await editorPreprocessor(writeData.content)
+        content: await editorPreprocessor(writeData.content),
+        emoji: writeData.emoji
       });
       toast('새로운 일기를 작성했어요!', { icon: EMOJI_LIST.GREEN_BOOK });
       router.push('/diary');
@@ -103,7 +113,9 @@ const Page: FC = () => {
         <Editor value={writeData.content} onChange={(v) => setWriteData((prev) => ({ ...prev, content: v }))} />
 
         <div className="mt-10 flex items-center justify-end">
-          <p className="mr-4 text-sm text-gray-500">{writeData.content.length}/500</p>
+          <p className="mr-4 text-sm text-gray-500">
+            {writeData.content.length}/{DIARY_MAX_LENGTH}
+          </p>
           <Button className="bg-green-600 text-white hover:bg-green-700" onClick={onSaveClick}>
             저장하기
           </Button>

--- a/src/app/write/page.tsx
+++ b/src/app/write/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { ChangeEvent, FC, useEffect, useState } from 'react';
+import { ChangeEvent, FC, useEffect, useRef, useState } from 'react';
 import PageTitle from '@/components/Typography/PageTitle';
 import Container from '@/components/Container';
 import Input from '@/components/Input';
@@ -11,14 +11,21 @@ import { createDiaryMutation } from '@/api/mutation/diary-mutation';
 import { useRouter } from 'next/navigation';
 import { EMOJI_LIST } from '@/constants/emoji';
 import { editorPreprocessor } from '@/utils/diary-preprocessor';
+import { DiaryWriteDataForm } from '@/app/write/type';
+import EmojiPicker from '@/components/EmojiPicker';
 
 const Page: FC = () => {
-  const [title, setTitle] = useState('');
-  const [content, setContent] = useState('');
   const router = useRouter();
+  const [writeData, setWriteData] = useState<DiaryWriteDataForm>({
+    emoji: '😊',
+    title: '',
+    content: ''
+  });
+  const [showEmoji, setShowEmoji] = useState(false);
+  const pickerContainerRef = useRef<HTMLDivElement>(null);
 
   const validateInput = () => {
-    if (content.trim() === '') {
+    if (writeData.content.trim() === '') {
       toast('일기 내용이 비어있어요.', { icon: EMOJI_LIST.PENCIL });
       return false;
     }
@@ -33,13 +40,13 @@ const Page: FC = () => {
 
     try {
       const defaultTitle = `${new Date().getMonth() + 1}월 ${new Date().getDate()}일 일기`;
-      if (title.trim() === '') {
-        setTitle(defaultTitle);
+      if (writeData.title.trim() === '') {
+        setWriteData((prev) => ({ ...prev, title: defaultTitle }));
       }
 
       await createDiaryMutation({
-        title: title.trim() === '' ? defaultTitle : title,
-        content: await editorPreprocessor(content)
+        title: writeData.title.trim() === '' ? defaultTitle : writeData.title,
+        content: await editorPreprocessor(writeData.content)
       });
       toast('새로운 일기를 작성했어요!', { icon: EMOJI_LIST.GREEN_BOOK });
       router.push('/diary');
@@ -49,14 +56,21 @@ const Page: FC = () => {
   };
 
   useEffect(() => {
-    const handleBeforeUnload = (e: BeforeUnloadEvent) => {
+    const handleUnloadPage = (e: BeforeUnloadEvent) => {
       e.preventDefault();
     };
+    const handleCloseEmojiPicker = (e: MouseEvent) => {
+      if (pickerContainerRef.current && !pickerContainerRef.current.contains(e.target as Node)) {
+        setShowEmoji(false);
+      }
+    };
 
-    window.addEventListener('beforeunload', handleBeforeUnload);
+    window.addEventListener('beforeunload', handleUnloadPage);
+    document.addEventListener('mousedown', handleCloseEmojiPicker);
 
     return () => {
-      window.removeEventListener('beforeunload', handleBeforeUnload);
+      window.removeEventListener('beforeunload', handleUnloadPage);
+      document.removeEventListener('mousedown', handleCloseEmojiPicker);
     };
   }, []);
 
@@ -64,15 +78,32 @@ const Page: FC = () => {
     <Container className="mt-12 lg:mt-20">
       <PageTitle title="일기 쓰기" description="새로운 일기를 쓸 수 있어요." />
       <div className="mt-16">
+        <div className="relative" ref={pickerContainerRef}>
+          <Input
+            className="absolute !w-11 text-center"
+            onClick={() => setShowEmoji(true)}
+            value={writeData.emoji}
+            onChange={(e: ChangeEvent<HTMLInputElement>) =>
+              setWriteData((prev) => ({ ...prev, emoji: e.target.value }))
+            }
+          />
+          <EmojiPicker
+            isOpen={showEmoji}
+            onEmoji={(emoji) => setWriteData((prev) => ({ ...prev, emoji }))}
+            onClose={() => setShowEmoji(false)}
+          />
+        </div>
         <Input
           placeholder="제목을 빈 칸으로 두면 오늘 날짜로 채워드릴게요."
-          value={title}
-          onChange={(e: ChangeEvent<HTMLInputElement>) => setTitle(e.target.value)}
-          className="mb-4"
+          value={writeData.title}
+          onChange={(e: ChangeEvent<HTMLInputElement>) => setWriteData((prev) => ({ ...prev, title: e.target.value }))}
+          className="mb-4 ml-14 w-[calc(100%-56px)] lg:w-1/2"
         />
-        <Editor value={content} onChange={setContent} />
+
+        <Editor value={writeData.content} onChange={(v) => setWriteData((prev) => ({ ...prev, content: v }))} />
+
         <div className="mt-10 flex items-center justify-end">
-          <p className="mr-4 text-sm text-gray-500">{content.length}/500</p>
+          <p className="mr-4 text-sm text-gray-500">{writeData.content.length}/500</p>
           <Button className="bg-green-600 text-white hover:bg-green-700" onClick={onSaveClick}>
             저장하기
           </Button>

--- a/src/app/write/type.ts
+++ b/src/app/write/type.ts
@@ -1,0 +1,5 @@
+export interface DiaryWriteDataForm {
+  readonly emoji: string;
+  readonly title: string;
+  readonly content: string;
+}

--- a/src/components/DiaryList/index.tsx
+++ b/src/components/DiaryList/index.tsx
@@ -33,7 +33,12 @@ export const DiaryList: FC = () => {
         )}
         {diaryData.content.length > 0 &&
           diaryData.content.map((diary) => (
-            <MyDiaryCard id={diary.diaryId} title={diary.title} date={new Date(diary.createdAt)} key={diary.diaryId} />
+            <MyDiaryCard
+              id={diary.diaryId}
+              title={`${diary.emoji} ${diary.title}`}
+              date={new Date(diary.createdAt)}
+              key={diary.diaryId}
+            />
           ))}
       </div>
       {diaryData.page.number + 1 < diaryData.page.totalPages && (

--- a/src/components/Editor/index.tsx
+++ b/src/components/Editor/index.tsx
@@ -69,11 +69,10 @@ const Editor: FC<EditorProps> = ({ value, onChange }) => {
     () => ({
       toolbar: {
         container: [
-          [{ header: '1' }, { header: '2' }, { header: '3' }],
           ['bold', 'italic', 'underline', 'strike'],
           [{ color: [] }, { background: [] }],
           [{ align: [] }],
-          ['link', 'image'],
+          ['image'],
           ['clean']
         ],
         handlers: {

--- a/src/components/EmojiPicker/index.tsx
+++ b/src/components/EmojiPicker/index.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { FC } from 'react';
+import dynamic from 'next/dynamic';
+import { cn } from '@/utils/cn';
+import { EmojiStyle } from 'emoji-picker-react';
+import { REACTION_LIST } from '@/constants/emoji';
+
+interface EmojiPickerProps {
+  readonly isOpen?: boolean;
+  readonly onClose?: () => void;
+  readonly onEmoji?: (emoji: string) => void;
+}
+
+const Picker = dynamic(() => import('emoji-picker-react'), { ssr: false });
+
+const EmojiPicker: FC<EmojiPickerProps> = ({ isOpen, onClose, onEmoji }) => {
+  return (
+    <div className={cn('!absolute top-12 z-10 opacity-100 transition-opacity ease-in', !isOpen && '!opacity-0')}>
+      <Picker
+        emojiStyle={EmojiStyle.NATIVE}
+        skinTonesDisabled
+        reactionsDefaultOpen={true}
+        reactions={Object.keys(REACTION_LIST)}
+        onReactionClick={(emoji) => {
+          onEmoji?.(emoji.emoji);
+          onClose?.();
+        }}
+        onEmojiClick={(emoji) => {
+          onEmoji?.(emoji.emoji);
+          onClose?.();
+        }}
+      />
+    </div>
+  );
+};
+
+export default EmojiPicker;

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -30,27 +30,17 @@ const Footer: FC = () => {
           </div>
           <div className="flex flex-col space-y-0.5">
             <Link href="/survey" className="text-gray-400 hover:text-gray-500">
-              알려진 오류 &middot; 피드백
+              알려진 오류
             </Link>
           </div>
           <div className="flex flex-col space-y-0.5">
             <a
-              href="https://github.com/SkyLightQP/maru-frontend"
+              href="https://github.com/maru-app/"
               target="_blank"
               rel="noreferrer"
               className="flex items-center text-gray-400 transition ease-in-out hover:text-gray-500"
             >
               <FontAwesomeIcon icon={faGithub} className="size-4" />
-              &nbsp;프론트엔드
-            </a>
-            <a
-              href="https://github.com/SkyLightQP/maru-backend"
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center text-gray-400 transition ease-in-out hover:text-gray-500"
-            >
-              <FontAwesomeIcon icon={faGithub} className="size-4" />
-              &nbsp;백엔드
             </a>
           </div>
         </div>

--- a/src/components/Landing/Jumbotron/index.tsx
+++ b/src/components/Landing/Jumbotron/index.tsx
@@ -30,9 +30,9 @@ const Jumbotron: FC = async () => {
             initial={{ y: -50, opacity: 0 }}
             animate={{ y: 0, opacity: 1 }}
             transition={{ duration: 0.35, ease: 'easeOut' }}
-            className="mb-2 text-3xl font-bold"
+            className="mb-3 text-2xl font-bold lg:text-3xl"
           >
-            나만의 일기를 쓰는 공간 <span className="font-dodamdodam text-4xl">마루</span>
+            나만의 일기를 쓰는 공간 마루
           </MotionH1>
           <DynamicIntroduce status={textStatus} />
         </div>

--- a/src/components/Streak/index.tsx
+++ b/src/components/Streak/index.tsx
@@ -15,7 +15,7 @@ const Streak: FC = async () => {
 
   return (
     <div className="mt-2 w-full rounded-md border border-gray-200 p-4">
-      <h3 className="mb-4 text-xl font-bold">
+      <h3 className="mb-4 text-xl font-bold leading-6">
         {streak === 0 ? (
           <>
             오늘은 아직 일기를 쓰지 않았어요. <br />
@@ -25,10 +25,9 @@ const Streak: FC = async () => {
           </>
         ) : (
           <>
-            <span aria-label="불 이모지">🔥</span> 연속 기록을 <span className="text-green-600">{streak}일</span> 유지
-            중이에요.
+            연속 기록을 <span className="text-green-600">{streak}일</span> 유지 중이에요.
             <br />
-            <span className="text-lg">
+            <span className="text-base">
               최장 연속 기록은 <span className="text-green-600">{bestStreak}일</span>이에요.
             </span>
           </>

--- a/src/constants/diary-validation.ts
+++ b/src/constants/diary-validation.ts
@@ -1,0 +1,2 @@
+export const DIARY_MAX_LENGTH = 500;
+export const EMOJI_MAX_LENGTH = 11; // 일부 이모지는 11자 차지

--- a/src/constants/emoji.ts
+++ b/src/constants/emoji.ts
@@ -4,3 +4,13 @@ export const EMOJI_LIST = {
   TRASH: '🗑️',
   WARNING: '🚧'
 };
+
+export const REACTION_LIST = {
+  '1f60a': '😊',
+  '1f970': '🥰',
+  '1f634': '😴',
+  '1f622': '😢',
+  '2600-fe0f': '☀️',
+  '1f325-fe0f': '🌤️',
+  '1f327-fe0f': '🌧️'
+};

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -7,7 +7,7 @@ export default {
     extend: {
       fontFamily: {
         dodamdodam: ['KCC-DodamdodamR', 'sans-serif'],
-        pretendard: ['Pretendard Variable', 'Fluent Emoji Color', ...defaultTheme.fontFamily.sans]
+        pretendard: ['Pretendard Variable', 'Fluent Emoji Flat', ...defaultTheme.fontFamily.sans]
       }
     }
   },


### PR DESCRIPTION
- 일기 작성(수정) 시 감정, 날씨, 기타 이모지를 설정할 수 있는 항목 추가
- Footer 컨텐츠 변경
  - Repository 주소 업데이트
- 일기 작성(수정) 시 500자 글자 제한 추가
- 위지윅 데이터에서 제목 스타일 및 하이퍼링크 추가 기능 삭제
- 모바일 환경에서의 텍스트 사이즈 변경
- Next.js 업그레이드

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added emoji support to diary entries, allowing users to select and display emojis with each diary.
  - Introduced an emoji picker component for easy emoji selection when writing or editing diary entries.

- **Enhancements**
  - Diary titles now display the selected emoji alongside the text in diary lists and detail pages.
  - Improved diary editor toolbar by simplifying formatting options.
  - Updated font and emoji styling for a more consistent appearance.

- **Validation**
  - Added input validation for emoji and diary content length.

- **UI Updates**
  - Refined layout and styling for diary writing, editing, and landing page sections.
  - Simplified footer content and GitHub links.
  - Adjusted streak display by removing the fire emoji and updating font sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->